### PR TITLE
Improve change API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,3 @@ authors = ["Nick Cameron <ncameron@mozilla.com>"]
 
 [dependencies]
 rls-analysis = { git = "https://github.com/nrc/rls-analysis" }
-serde = "0.8"
-serde_json = "0.8"
-serde_derive = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,3 @@
 name = "rls-vfs"
 version = "0.1.0"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
-
-[dependencies]
-rls-analysis = { git = "https://github.com/nrc/rls-analysis" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,4 @@
-#![feature(proc_macro)]
-
 extern crate rls_analysis;
-#[macro_use]
-extern crate serde_derive;
 
 use rls_analysis::Span;
 
@@ -27,7 +23,7 @@ macro_rules! try_opt_loc {
 
 pub struct Vfs<U = ()>(VfsInternal<RealFileLoader, U>);
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug)]
 pub struct Change {
     pub span: Span,
     pub text: String,


### PR DESCRIPTION
Warning: this is completely experimental, tests don't compile and it might not be a good idea at all : )

There's a problem with the current `on_change` API: it does not allow to set the contents of the file, and only apply changes to it. 

So the initial version of the file is fetched from disk, and I believe this does not work properly, because it might be not the version to which the changes are intended to be applied. 

This I believe is the reason why LSP allows to send `null` as a `range` of the [TextDocumentContentChangeEvent](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#textDocument_didChange): this signals non incremental update. 


This PR contains musings about who this should be handled on the lowest level of VFS. 

The idea is to introduce three kinds of changes: enable in memory representation, change in memory representation, disable in memory representation and use hard drive instead. 

Does this sound reasonable? 