### PR TITLE
Use our own Span instead of rls-analysis one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,3 @@
 name = "rls-vfs"
 version = "0.1.0"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
-
-[dependencies]
-rls-analysis = { git = "https://github.com/nrc/rls-analysis" }

--- a/src/text_grid.rs
+++ b/src/text_grid.rs
@@ -1,0 +1,80 @@
+use std::ops::{Index, Add};
+
+/// One-based line number.
+#[derive(Debug, Clone, Copy)]
+pub struct Line(pub u32);
+
+/// One-based column number.
+#[derive(Debug, Clone, Copy)]
+pub struct Column(pub u32);
+
+#[derive(Debug, Clone, Copy)]
+pub struct Span {
+    pub start: (Line, Column),
+    pub end: (Line, Column),
+}
+
+impl From<((usize, usize), (usize, usize))> for Span {
+    fn from(((l1, c1), (l2, c2)): ((usize, usize), (usize, usize))) -> Self {
+        fn to_u32(x: usize) -> u32 {
+            assert!(x < u32::max_value() as usize);
+            x as u32
+        }
+
+        Span {
+            start: (Line(to_u32(l1)), Column(to_u32(c1))),
+            end: (Line(to_u32(l2)), Column(to_u32(c2))),
+        }
+    }
+}
+
+/// Maps `Line` to byte offset.
+pub struct LinesIndex(Vec<u32>);
+
+impl LinesIndex {
+    pub fn from_str(text: &str) -> Self {
+        let mut result = vec![0];
+        for (i, b) in text.bytes().enumerate() {
+            if b == 0xA {
+                result.push((i + 1) as u32);
+            }
+        }
+        result.push(text.len() as u32);
+        LinesIndex(result)
+    }
+}
+
+impl LinesIndex {
+    pub fn get(&self, index: Line) -> Option<&u32> {
+        self.0.get(index.0 as usize)
+    }
+}
+
+impl Index<Line> for LinesIndex {
+    type Output = u32;
+
+    fn index(&self, index: Line) -> &u32 {
+        &self.0[index.0 as usize]
+    }
+}
+
+impl Add<u32> for Line {
+    type Output = Line;
+
+    fn add(self, rhs: u32) -> Line {
+        Line(self.0 + rhs)
+    }
+}
+
+// c is a character offset, returns a byte offset
+pub fn byte_in_line(line: &str, c: Column) -> Option<usize> {
+    // We simulate a null-terminated string here because spans are exclusive at
+    // the top, and so that index might be outside the length of the string.
+    for (i, (b, _)) in line.char_indices().chain(Some((line.len(), '\0')).into_iter()).enumerate() {
+        if c.0 as usize == i {
+            return Some(b);
+        }
+    }
+
+    return None;
+}


### PR DESCRIPTION
Let's see how implementing yet another `Span` works out!

>I'm not sure there is a great advantage to splitting the file out of the span - it's usually a pretty small number of bytes and there is some advantage in strongly associating a range with a file

Hm, but all those bytes are allocated on the heap. Without file_name, a span is `Copy`. And I don't think having a file name around provides strong guarantees, because you apply span to the text of the file, which is not connected to the name really.

>all these different formats for the same thing is a pain. 

Yep, that's unfortunate. If they all are one based though, this can be somewhat ameliorated by round-tripping through structural type like `[usize; 4]`. We also don't increase the absolute number of transofmations in rls: now lsp-span is translated to analysis span, after this change it would be translated to vfs span.


I'd send a related PR to rls, but unfortunately I can't build it now because of
 
> error: the `#[proc_macro_derive]` attribute is only usable with crates of the `proc-macro` crate type
