### PR TITLE
Alternative support for len field in ReplaceText event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "rls-vfs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "racer 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rls-vfs"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "Virtual File System for the RLS"
 license = "Apache-2.0/MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,12 @@ pub enum Change {
     ReplaceText {
         /// Span of the text to be replaced defined in col/row terms.
         span: Span,
+        /// Length in chars of the text to be replaced. If present,
+        /// used to calculate replacement range instead of
+        /// span's row_end/col_end fields. Needed for editors that
+        /// can't properly calculate the latter fields.
+        /// Span's row_start/col_start are still assumed valid.
+        len: Option<u64>,
         /// Text to replace specified text range with.
         text: String,
     },
@@ -416,15 +422,27 @@ impl<U> File<U> {
     fn make_change(&mut self, changes: &[&Change]) -> Result<(), Error> {
         for c in changes {
             let new_text = match **c {
-                Change::ReplaceText { ref span, ref text } => {
+                Change::ReplaceText { ref span, ref len, ref text } => {
                     let range = {
                         let first_line = self.load_line(span.range.row_start).unwrap();
-                        let last_line = self.load_line(span.range.row_end).unwrap();
-
                         let byte_start = self.line_indices[span.range.row_start.0 as usize] +
                             byte_in_str(first_line, span.range.col_start).unwrap() as u32;
-                        let byte_end = self.line_indices[span.range.row_end.0 as usize] +
-                            byte_in_str(last_line, span.range.col_end).unwrap() as u32;
+
+                        let byte_end = if let &Some(len) = len {
+                            // if `len` exists, the replaced portion of text
+                            // is `len` chars starting from row_start/col_start.
+                            byte_start + byte_in_str(
+                                &self.text[byte_start as usize..],
+                                span::Column::new_zero_indexed(len as u32)
+                            ).unwrap() as u32
+                        } else {
+                            // if no `len`, fall back to using row_end/col_end
+                            // for determining the tail end of replaced text.
+                            let last_line = self.load_line(span.range.row_end).unwrap();
+                            self.line_indices[span.range.row_end.0 as usize] +
+                                byte_in_str(last_line, span.range.col_end).unwrap() as u32
+                        };
+
                         (byte_start, byte_end)
                     };
                     let mut new_text = self.text[..range.0 as usize].to_owned();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,9 @@ pub enum Change {
     },
     /// Changes in-memory contents of the previously added file.
     ReplaceText {
+        /// Span of the text to be replaced defined in col/row terms.
         span: Span,
+        /// Text to replace specified text range with.
         text: String,
     },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,19 +421,8 @@ impl<U> File<U> {
 
                         let byte_start = self.line_indices[span.range.row_start.0 as usize] +
                             byte_in_str(first_line, span.range.col_start).unwrap() as u32;
-                        let byte_end = if let Some(len) = span.range.length {
-                            // NOTE: The rest of the file is treated as a continous line here, so we
-                            // can use the `bytes_in_str` method to count up the bytes instead of
-                            // rolling our own. Counting up is neccessary since there might be
-                            // characters that span multiple bytes
-                            byte_start
-                                + byte_in_str(&self.text[byte_start as usize..], span::Column::new_zero_indexed(len as u32)).unwrap() as u32
-                        } else {
-                            // if we don't have a range set, use the `end` position instead.
-                            self.line_indices[span.range.row_end.0 as usize] +
-                                byte_in_str(last_line, span.range.col_end).unwrap() as u32
-                        };
-
+                        let byte_end = self.line_indices[span.range.row_end.0 as usize] +
+                            byte_in_str(last_line, span.range.col_end).unwrap() as u32;
                         (byte_start, byte_end)
                     };
                     let mut new_text = self.text[..range.0 as usize].to_owned();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,7 +421,7 @@ impl<U> File<U> {
 
                         let byte_start = self.line_indices[span.range.row_start.0 as usize] +
                             byte_in_str(first_line, span.range.col_start).unwrap() as u32;
-                        let byte_end = if let Some(len) = span.range.len {
+                        let byte_end = if let Some(len) = span.range.length {
                             // NOTE: The rest of the file is treated as a continous line here, so we
                             // can use the `bytes_in_str` method to count up the bytes instead of
                             // rolling our own. Counting up is neccessary since there might be


### PR DESCRIPTION
This reverts #12 and #13 made in preparation of rust-lang-nursery/rls#281.

And further adds code necessary for rust-lang-nursery/rls#283.