### PR TITLE
Handle UTF-16 code unit offsets in file changes API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rls-vfs"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,17 @@
 [[package]]
+name = "cfg-if"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rls-span"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7,8 +20,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rls-vfs"
 version = "0.6.0"
 dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
+"checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d7c7046dc6a92f2ae02ed302746db4382e75131b9ce20ce967259f6b5867a6a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ categories = ["development-tools"]
 
 [dependencies]
 rls-span = "0.4"
+log = "0.4.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rls-vfs"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "Virtual File System for the RLS"
 license = "Apache-2.0/MIT"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -7,7 +7,7 @@ extern crate rls_vfs;
 extern crate test;
 
 use rls_span::{Column, Position, Row, Span};
-use rls_vfs::Change;
+use rls_vfs::{Change, SpanAtom};
 use std::fs;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -51,6 +51,7 @@ fn make_change_(path: &Path, start_line: usize, interval: usize) -> Change {
         span: Span::from_positions(start, end, path),
         len: None,
         text: buf,
+        atom: SpanAtom::UnicodeScalarValue,
     }
 }
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -7,7 +7,7 @@ extern crate rls_vfs;
 extern crate test;
 
 use rls_span::{Column, Position, Row, Span};
-use rls_vfs::{Change, SpanAtom};
+use rls_vfs::{Change, VfsSpan};
 use std::fs;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -48,10 +48,8 @@ fn make_change_(path: &Path, start_line: usize, interval: usize) -> Change {
     );
     let buf = (0..LEN).map(|_| txt.to_owned() + "\n").collect::<String>();
     Change::ReplaceText {
-        span: Span::from_positions(start, end, path),
-        len: None,
+        span: VfsSpan::from_usv(Span::from_positions(start, end, path), None),
         text: buf,
-        atom: SpanAtom::UnicodeScalarValue,
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![feature(type_ascription)]
 
 extern crate rls_span as span;
+#[macro_use]
+extern crate log;
 
 use std::collections::HashMap;
 use std::fmt;
@@ -292,6 +294,7 @@ impl<T: FileLoader, U> VfsInternal<T, U> {
     }
 
     fn on_changes(&self, changes: &[Change]) -> Result<(), Error> {
+        trace!("on_changes: {:?}", changes);
         for (file_name, changes) in coalesce_changes(changes) {
             let path = Path::new(file_name);
             {
@@ -652,7 +655,9 @@ impl<U> File<U> {
 
 impl TextFile {
     fn make_change(&mut self, changes: &[&Change]) -> Result<(), Error> {
+        trace!("TextFile::make_change");
         for c in changes {
+            trace!("TextFile::make_change: {:?}", c);
             let new_text = match **c {
                 Change::ReplaceText {
                     ref span,


### PR DESCRIPTION
This adds the ability to change text with ranges defined in UTF-16 code units (per LSP spec, needed for the RLS).

Since we embed index base in `Span` type, we could also embed the 'text atom' there as well. Should we do that?
The tricky bit is that conversion between those requires a source buffer - to change from 0-based to 1-based indexing we only need to add/subtract 1 but to translate column offset we need actual string of characters for which the range is defined.
Since we need the source buffer, I decided that it'd be best to implement that API on VFS directly, because it operates on the buffer directly.

Should I come up with more tests? Previously crashing UTF-16 test case now works and RLS using this patched vfs version doesn't crash and reformats succesfully the test case from https://github.com/rust-lang-nursery/rls/issues/1104.